### PR TITLE
docs(readme): point the desktop download links at downloads.mindshub.ai (ENG-1437)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ This repository is the **platform superproject**: it pulls together the desktop/
 Pick whichever fits:
 
 - **Web — nothing to install.** Open **[console.mindshub.ai](https://console.mindshub.ai/?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme)** and sign in.
-- **macOS.** [Download the desktop app](https://downloads.mindsdb.com/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
-- **Windows.** [Download the desktop app](https://downloads.mindsdb.com/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
+- **macOS.** [Download the desktop app](https://downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg) (`.pkg`).
+- **Windows.** [Download the desktop app](https://downloads.mindshub.ai/mindshub-cowork/windows/mindshub-cowork-latest.exe) (`.exe`).
 - **Run it open source.** [Build from source](#build-from-source) — see below.
 
 Free to start. Pro adds all frontier models and private artifacts — see [pricing](https://mindshub.ai/pricing?utm_source=github&utm_medium=repo-readme&utm_campaign=minds-readme).

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -398,7 +398,7 @@
           </div>
           <div class="dl-arrow">↗</div>
         </a>
-        <a class="download-card" href="https://downloads.mindsdb.com/anton/mac/anton-latest.pkg" target="_blank">
+        <a class="download-card" href="https://downloads.mindshub.ai/anton/mac/anton-latest.pkg" target="_blank">
           <div class="dl-icon">
             <svg width="22" height="22" viewBox="0 0 814 1000" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="color:var(--ink-2)">
               <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-43.4-150.3-116.6c-52.1-83.6-94.1-208.7-94.1-328.2 0-191.3 124.1-292.5 246.9-292.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/>
@@ -414,7 +414,7 @@
             </svg>
           </div>
         </a>
-        <a class="download-card" href="https://downloads.mindsdb.com/anton/windows/anton-latest.exe" target="_blank">
+        <a class="download-card" href="https://downloads.mindshub.ai/anton/windows/anton-latest.exe" target="_blank">
           <div class="dl-icon">
             <svg width="22" height="22" viewBox="0 0 88 88" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="color:var(--ink-2)">
               <path d="M0 12.402l35.687-4.86.016 34.423-35.67.203zm35.67 33.529l.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349l-.015 41.344-47.318-6.63-.066-34.893z"/>


### PR DESCRIPTION
## Story

**As a** developer landing on this README for the first time
**I want** the install links to name the canonical download host
**So that** the first host I learn is the one every other surface uses

## Context

ENG-437 migrated download URLs from `downloads.mindsdb.com` to `downloads.mindshub.ai` and closed as Done, but a handful of consumers were never repointed. The **pick whichever fits** install list here is one of them.

Nothing was broken: both names are aliases on the same CloudFront distribution, so the old links have always served the same bytes. The README is simply the first thing a new reader sees, and it was teaching the legacy host.

**Only the superproject README changes.** `backend/core_agent` is the `mindsdb/anton` submodule and carries the same two links in its own README. That copy is fixed in [anton#340](https://github.com/mindsdb/anton/pull/340) and arrives here with the next pin bump. Editing it from inside the submodule would produce a detached commit nothing points at, which is exactly the failure mode `CLAUDE.md` warns about.

`frontend/README.md` (the `mindsdb/cowork` submodule) already documents the canonical host and needs no change.

## Acceptance criteria

- [x] The superproject `README.md` references no `downloads.mindsdb.com` link.
- [x] Both install links resolve to a live installer on `downloads.mindshub.ai`.
- [x] Negative: no submodule pointer moves in this PR.

## How to test

1. `grep -n "downloads.mindsdb.com" README.md` — expect no hits.
2. `git diff --stat origin/staging...HEAD` — expect `README.md` only, no submodule entries.
3. Click both links in the rendered README, or check without downloading 220 MB:
   ```
   curl -sSI https://downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg | head -1
   ```
   It answered `200` when this was written.

## Notes

**The legacy alias stays live** and is not being retired.

Cross-repo: part of ENG-1437, alongside open PRs on `mindsdb/website` (#104), `mindsdb/mindshub_frontend` (#1418), `mindsdb/auth` (#270), `mindsdb/anton` (#340), and `mindsdb/terraform`. Independent; merge order does not matter.

Refs: ENG-1437