### PR TITLE
docs: signpost the hosted MindsHub API from the Cowork docs pages (ENG-1745)

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -79,7 +79,11 @@
   nav[data-open] .hamburger span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
   nav[data-open] .hamburger span:nth-child(2) { opacity: 0; width: 0; }
   nav[data-open] .hamburger span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
-  @media (max-width: 640px) {
+  /* Raised from 640px. The row needs 719px once the back control is in it:
+     79 back + 117 brand + 411 links + 64 gaps + 48 padding. Below that and
+     above the old breakpoint the brand and every link wrapped inside a bar
+     still pinned at 52px, which no horizontal-overflow check can see. */
+  @media (max-width: 760px) {
     .hamburger { display: flex; }
     .nav-links {
       display: none;
@@ -258,7 +262,7 @@
       white-space: nowrap;
       transition: color 120ms;
     }
-    .nav-up:hover { color: var(--accent); }
+    .nav-up:hover { color: var(--accent); opacity: 1; }
   </style>
 </head>
 <body>
@@ -277,7 +281,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html" class="active">API</a>
-      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">

--- a/docs/api.html
+++ b/docs/api.html
@@ -255,6 +255,10 @@
   <div class="nav-inner">
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
+      <!-- Back to the chooser page at the root of the hostname. These docs
+           sit at /cowork, so the navbar brand returns to this set rather than
+           to the hostname, and without this there is no way back out. -->
+      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/api.html
+++ b/docs/api.html
@@ -105,6 +105,48 @@
   .nav-links a:hover { color: var(--ink); opacity: 1; }
   .nav-links a.active { color: var(--accent); }
 
+  /* ── Hosted API banner ── */
+  .api-banner {
+    background: var(--accent-bg);
+    border-bottom: 1px solid var(--line);
+  }
+  .api-banner-inner {
+    max-width: 1100px; margin: 0 auto;
+    padding: 10px 24px;
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+    font-size: 13px; line-height: 1.55; color: var(--ink-3);
+  }
+  .api-banner-tag {
+    font-family: var(--font-mono);
+    font-size: 10px; font-weight: 600;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid rgba(34,211,238,0.30);
+    border-radius: 100px; padding: 2px 9px;
+    white-space: nowrap;
+  }
+  .api-banner-text { flex: 1; min-width: 240px; }
+  .api-banner-text a { font-weight: 500; }
+
+  /* ── Local server note ── */
+  .local-note {
+    background: var(--accent-bg);
+    border: 1px solid rgba(34,211,238,0.30);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--r-lg);
+    padding: 18px 20px;
+    margin-bottom: 44px;
+  }
+  .local-note .ln-head {
+    font-family: var(--font-mono);
+    font-size: 11px; font-weight: 600;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 10px;
+  }
+  .local-note p { font-size: 13.5px; line-height: 1.6; color: var(--ink-2); }
+  .local-note p + p { margin-top: 10px; }
+
   .shell { max-width: 1100px; margin: 0 auto; padding: 64px 24px 120px; display: grid; grid-template-columns: 220px 1fr; gap: 0; align-items: start; }
   @media (max-width: 768px) { .shell { grid-template-columns: 1fr; } }
 
@@ -217,6 +259,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html" class="active">API</a>
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -224,6 +267,17 @@
     </button>
   </div>
 </nav>
+
+<div class="api-banner">
+  <div class="api-banner-inner">
+    <span class="api-banner-tag">Hosted API</span>
+    <span class="api-banner-text">
+      These pages document Minds Cowork, the app and local server you run yourself.
+      For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+    </span>
+  </div>
+</div>
 
 <div class="shell">
   <aside class="sidebar">
@@ -251,6 +305,20 @@
       The Cowork server exposes a versioned REST API at <code>/api/v1</code>.
       All endpoints return JSON.
     </p>
+
+    <div class="local-note">
+      <div class="ln-head">This page documents the local Cowork server</div>
+      <p>
+        Every endpoint below belongs to the Cowork server that runs on your own machine, at
+        <code>http://localhost:26866/api/v1</code>. It takes no API key and it is not reachable
+        over the internet.
+      </p>
+      <p>
+        The hosted MindsHub API is a different service. It runs at <code>api.mindshub.ai</code>,
+        it needs an API key, and it is documented separately:
+        <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+      </p>
+    </div>
 
     <!-- ERD -->
     <div class="erd-wrap">

--- a/docs/api.html
+++ b/docs/api.html
@@ -247,18 +247,32 @@
   .p-desc code { font-size: 0.9em; }
 
   footer { border-top: 1px solid var(--line); padding: 24px; text-align: center; font-family: var(--font-mono); font-size: 11px; color: var(--ink-4); letter-spacing: 0.06em; }
-</style>
+    /* The back control. Mono and uppercase so it sits with the brand beside it,
+       but dimmer and tighter-tracked so it does not read as part of it. */
+    .nav-up {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      white-space: nowrap;
+      transition: color 120ms;
+    }
+    .nav-up:hover { color: var(--accent); }
+  </style>
 </head>
 <body>
 
 <nav>
   <div class="nav-inner">
+    <!-- Back to the chooser page at the root of the hostname. First in the
+         row, before the brand, which is where a back control is looked for.
+         Deliberately outside .nav-links: that collapses into the mobile
+         menu, and the only way out of this documentation set should not be
+         hidden behind a hamburger. -->
+    <a href="/" class="nav-up">&larr; All docs</a>
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
-      <!-- Back to the chooser page at the root of the hostname. These docs
-           sit at /cowork, so the navbar brand returns to this set rather than
-           to the hostname, and without this there is no way back out. -->
-      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/api.html
+++ b/docs/api.html
@@ -259,7 +259,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html" class="active">API</a>
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -274,7 +274,7 @@
     <span class="api-banner-text">
       These pages document Minds Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
   </div>
 </div>
@@ -316,7 +316,7 @@
       <p>
         The hosted MindsHub API is a different service. It runs at <code>api.mindshub.ai</code>,
         it needs an API key, and it is documented separately:
-        <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+        <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
       </p>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,6 +323,10 @@
       Minds Cowork
     </div>
     <div class="nav-links">
+      <!-- Back to the chooser page at the root of the hostname. These docs
+           sit at /cowork, so the navbar brand returns to this set rather than
+           to the hostname, and without this there is no way back out. -->
+      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html" class="active">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,6 +128,29 @@
   .nav-links a:hover { color: var(--ink); opacity: 1; }
   .nav-links a.active { color: var(--accent); }
 
+  /* ── Hosted API banner ── */
+  .api-banner {
+    background: var(--accent-bg);
+    border-bottom: 1px solid var(--line);
+  }
+  .api-banner-inner {
+    max-width: 1100px; margin: 0 auto;
+    padding: 10px 24px;
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+    font-size: 13px; line-height: 1.55; color: var(--ink-3);
+  }
+  .api-banner-tag {
+    font-family: var(--font-mono);
+    font-size: 10px; font-weight: 600;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid rgba(34,211,238,0.30);
+    border-radius: 100px; padding: 2px 9px;
+    white-space: nowrap;
+  }
+  .api-banner-text { flex: 1; min-width: 240px; }
+  .api-banner-text a { font-weight: 500; }
+
   /* ── Hero ── */
   .hero-wrap {
     max-width: 1100px; margin: 0 auto;
@@ -304,6 +327,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -311,6 +335,17 @@
     </button>
   </div>
 </nav>
+
+<div class="api-banner">
+  <div class="api-banner-inner">
+    <span class="api-banner-tag">Hosted API</span>
+    <span class="api-banner-text">
+      These pages document Minds Cowork, the app and local server you run yourself.
+      For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+    </span>
+  </div>
+</div>
 
 <div class="hero-wrap">
   <div class="eyebrow">Documentation</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,21 +312,35 @@
     font-size: 11px; color: var(--ink-4);
     letter-spacing: 0.06em;
   }
-</style>
+    /* The back control. Mono and uppercase so it sits with the brand beside it,
+       but dimmer and tighter-tracked so it does not read as part of it. */
+    .nav-up {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      white-space: nowrap;
+      transition: color 120ms;
+    }
+    .nav-up:hover { color: var(--accent); }
+  </style>
 </head>
 <body>
 
 <nav>
   <div class="nav-inner">
+    <!-- Back to the chooser page at the root of the hostname. First in the
+         row, before the brand, which is where a back control is looked for.
+         Deliberately outside .nav-links: that collapses into the mobile
+         menu, and the only way out of this documentation set should not be
+         hidden behind a hamburger. -->
+    <a href="/" class="nav-up">&larr; All docs</a>
     <div class="brand">
       <div class="brand-dot"></div>
       Minds Cowork
     </div>
     <div class="nav-links">
-      <!-- Back to the chooser page at the root of the hostname. These docs
-           sit at /cowork, so the navbar brand returns to this set rather than
-           to the hostname, and without this there is no way back out. -->
-      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html" class="active">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,11 @@
   nav[data-open] .hamburger span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
   nav[data-open] .hamburger span:nth-child(2) { opacity: 0; width: 0; }
   nav[data-open] .hamburger span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
-  @media (max-width: 640px) {
+  /* Raised from 640px. The row needs 719px once the back control is in it:
+     79 back + 117 brand + 411 links + 64 gaps + 48 padding. Below that and
+     above the old breakpoint the brand and every link wrapped inside a bar
+     still pinned at 52px, which no horizontal-overflow check can see. */
+  @media (max-width: 760px) {
     .hamburger { display: flex; }
     .nav-links {
       display: none;
@@ -323,7 +327,7 @@
       white-space: nowrap;
       transition: color 120ms;
     }
-    .nav-up:hover { color: var(--accent); }
+    .nav-up:hover { color: var(--accent); opacity: 1; }
   </style>
 </head>
 <body>
@@ -345,7 +349,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">

--- a/docs/index.html
+++ b/docs/index.html
@@ -327,7 +327,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -342,7 +342,7 @@
     <span class="api-banner-text">
       These pages document Minds Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
   </div>
 </div>

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -129,6 +129,29 @@
   .nav-links a:hover { color: var(--ink); opacity: 1; }
   .nav-links a.active { color: var(--accent); }
 
+  /* ── Hosted API banner ── */
+  .api-banner {
+    background: var(--accent-bg);
+    border-bottom: 1px solid var(--line);
+  }
+  .api-banner-inner {
+    max-width: 1100px; margin: 0 auto;
+    padding: 10px 24px;
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+    font-size: 13px; line-height: 1.55; color: var(--ink-3);
+  }
+  .api-banner-tag {
+    font-family: var(--font-mono);
+    font-size: 10px; font-weight: 600;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid rgba(34,211,238,0.30);
+    border-radius: 100px; padding: 2px 9px;
+    white-space: nowrap;
+  }
+  .api-banner-text { flex: 1; min-width: 240px; }
+  .api-banner-text a { font-weight: 500; }
+
   /* ── Layout ── */
   .shell {
     max-width: 1100px; margin: 0 auto;
@@ -346,6 +369,7 @@
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -353,6 +377,17 @@
     </button>
   </div>
 </nav>
+
+<div class="api-banner">
+  <div class="api-banner-inner">
+    <span class="api-banner-tag">Hosted API</span>
+    <span class="api-banner-text">
+      These pages document Minds Cowork, the app and local server you run yourself.
+      For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+    </span>
+  </div>
+</div>
 
 <div class="shell">
   <aside class="sidebar">

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -103,7 +103,11 @@
   nav[data-open] .hamburger span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
   nav[data-open] .hamburger span:nth-child(2) { opacity: 0; width: 0; }
   nav[data-open] .hamburger span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
-  @media (max-width: 640px) {
+  /* Raised from 640px. The row needs 719px once the back control is in it:
+     79 back + 117 brand + 411 links + 64 gaps + 48 padding. Below that and
+     above the old breakpoint the brand and every link wrapped inside a bar
+     still pinned at 52px, which no horizontal-overflow check can see. */
+  @media (max-width: 760px) {
     .hamburger { display: flex; }
     .nav-links {
       display: none;
@@ -368,7 +372,7 @@
       white-space: nowrap;
       transition: color 120ms;
     }
-    .nav-up:hover { color: var(--accent); }
+    .nav-up:hover { color: var(--accent); opacity: 1; }
   </style>
 </head>
 <body>
@@ -387,7 +391,7 @@
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -369,7 +369,7 @@
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -384,7 +384,7 @@
     <span class="api-banner-text">
       These pages document Minds Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
   </div>
 </div>

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -365,6 +365,10 @@
   <div class="nav-inner">
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
+      <!-- Back to the chooser page at the root of the hostname. These docs
+           sit at /cowork, so the navbar brand returns to this set rather than
+           to the hostname, and without this there is no way back out. -->
+      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -357,18 +357,32 @@
     text-align: center; font-family: var(--font-mono);
     font-size: 11px; color: var(--ink-4); letter-spacing: 0.06em;
   }
-</style>
+    /* The back control. Mono and uppercase so it sits with the brand beside it,
+       but dimmer and tighter-tracked so it does not read as part of it. */
+    .nav-up {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      white-space: nowrap;
+      transition: color 120ms;
+    }
+    .nav-up:hover { color: var(--accent); }
+  </style>
 </head>
 <body>
 
 <nav>
   <div class="nav-inner">
+    <!-- Back to the chooser page at the root of the hostname. First in the
+         row, before the brand, which is where a back control is looked for.
+         Deliberately outside .nav-links: that collapses into the mobile
+         menu, and the only way out of this documentation set should not be
+         hidden behind a hamburger. -->
+    <a href="/" class="nav-up">&larr; All docs</a>
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
-      <!-- Back to the chooser page at the root of the hostname. These docs
-           sit at /cowork, so the navbar brand returns to this set rather than
-           to the hostname, and without this there is no way back out. -->
-      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -242,18 +242,32 @@
   .cta-btn:hover { opacity: 0.85; }
 
   footer { border-top: 1px solid var(--line); padding: 24px; text-align: center; font-family: var(--font-mono); font-size: 11px; color: var(--ink-4); letter-spacing: 0.06em; }
-</style>
+    /* The back control. Mono and uppercase so it sits with the brand beside it,
+       but dimmer and tighter-tracked so it does not read as part of it. */
+    .nav-up {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      white-space: nowrap;
+      transition: color 120ms;
+    }
+    .nav-up:hover { color: var(--accent); }
+  </style>
 </head>
 <body>
 
 <nav>
   <div class="nav-inner">
+    <!-- Back to the chooser page at the root of the hostname. First in the
+         row, before the brand, which is where a back control is looked for.
+         Deliberately outside .nav-links: that collapses into the mobile
+         menu, and the only way out of this documentation set should not be
+         hidden behind a hamburger. -->
+    <a href="/" class="nav-up">&larr; All docs</a>
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
-      <!-- Back to the chooser page at the root of the hostname. These docs
-           sit at /cowork, so the navbar brand returns to this set rather than
-           to the hostname, and without this there is no way back out. -->
-      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -99,6 +99,29 @@
   .nav-links a:hover { color: var(--ink); opacity: 1; }
   .nav-links a.active { color: var(--accent); }
 
+  /* ── Hosted API banner ── */
+  .api-banner {
+    background: var(--accent-bg);
+    border-bottom: 1px solid var(--line);
+  }
+  .api-banner-inner {
+    max-width: 1100px; margin: 0 auto;
+    padding: 10px 24px;
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+    font-size: 13px; line-height: 1.55; color: var(--ink-3);
+  }
+  .api-banner-tag {
+    font-family: var(--font-mono);
+    font-size: 10px; font-weight: 600;
+    letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid rgba(34,211,238,0.30);
+    border-radius: 100px; padding: 2px 9px;
+    white-space: nowrap;
+  }
+  .api-banner-text { flex: 1; min-width: 240px; }
+  .api-banner-text a { font-weight: 500; }
+
   /* ── Hero ── */
   .hero-wrap { max-width: 1100px; margin: 0 auto; padding: 88px 24px 72px; }
   .eyebrow { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
@@ -231,6 +254,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>
       <a href="api.html">API</a>
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -238,6 +262,17 @@
     </button>
   </div>
 </nav>
+
+<div class="api-banner">
+  <div class="api-banner-inner">
+    <span class="api-banner-tag">Hosted API</span>
+    <span class="api-banner-text">
+      These pages document Minds Cowork, the app and local server you run yourself.
+      For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
+      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+    </span>
+  </div>
+</div>
 
 <div class="hero-wrap">
   <div class="eyebrow">Use Cases</div>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -254,7 +254,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
@@ -269,7 +269,7 @@
     <span class="api-banner-text">
       These pages document Minds Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
-      <a href="https://mindsdb.github.io/mindshub_inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
+      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
   </div>
 </div>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -250,6 +250,10 @@
   <div class="nav-inner">
     <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
     <div class="nav-links">
+      <!-- Back to the chooser page at the root of the hostname. These docs
+           sit at /cowork, so the navbar brand returns to this set rather than
+           to the hostname, and without this there is no way back out. -->
+      <a href="/" class="nav-up">&larr; All docs</a>
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -73,7 +73,11 @@
   nav[data-open] .hamburger span:nth-child(1) { transform: translateY(6.5px) rotate(45deg); }
   nav[data-open] .hamburger span:nth-child(2) { opacity: 0; width: 0; }
   nav[data-open] .hamburger span:nth-child(3) { transform: translateY(-6.5px) rotate(-45deg); }
-  @media (max-width: 640px) {
+  /* Raised from 640px. The row needs 719px once the back control is in it:
+     79 back + 117 brand + 411 links + 64 gaps + 48 padding. Below that and
+     above the old breakpoint the brand and every link wrapped inside a bar
+     still pinned at 52px, which no horizontal-overflow check can see. */
+  @media (max-width: 760px) {
     .hamburger { display: flex; }
     .nav-links {
       display: none;
@@ -253,7 +257,7 @@
       white-space: nowrap;
       transition: color 120ms;
     }
-    .nav-up:hover { color: var(--accent); }
+    .nav-up:hover { color: var(--accent); opacity: 1; }
   </style>
 </head>
 <body>
@@ -272,7 +276,7 @@
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>
       <a href="api.html">API</a>
-      <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">Hosted API ↗</a>
+      <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
       <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">


### PR DESCRIPTION
Linear: [ENG-1745](https://linear.app/mindsdb/issue/ENG-1745)

## Description

`docs.mindshub.ai` is the address a developer guesses when they are looking for our hosted API, and right now it only shows Cowork content. Its largest page, `api.html`, is a REST reference for the **local** Cowork server at `http://localhost:26866/api/v1` with no auth header anywhere, so it reads like a cloud API reference when it is not.

This PR only adds a signpost. Nothing moves, nothing is removed, no redirect is introduced.

**All four pages** (`index.html`, `setup.html`, `use-cases.html`, `api.html`):

- A banner strip directly under the nav: "These pages document Minds Cowork, the app and local server you run yourself. For the hosted MindsHub API at api.mindshub.ai, with API keys, see the hosted MindsHub API docs."
- A `Hosted API ↗` item in the nav row, next to `GitHub ↗`.

**`api.html` also gets** a callout above the first endpoint (above the ERD and the base URL strip) saying the page documents the local Cowork server, that it takes no API key and is not reachable over the internet, and that the hosted MindsHub API at `api.mindshub.ai` is a different service with its own keys and its own docs.

## 20 Aug update: the link target changed, and so did the plan around it

The domain decision reversed after Costa's review ([ENG-1744](https://linear.app/mindsdb/issue/ENG-1744)). The developer docs go to `docs.mindshub.ai/inference`, not `console.mindshub.ai/docs`, and **these four pages move to `docs.mindshub.ai/cowork`** so neither product is a lodger in the other's house.

Two consequences for this PR:

- **The nine link targets now point at `https://docs.mindshub.ai/inference/`** (`62753a9`), the final address, rather than the `github.io` path they would have had to be corrected off later.
- **The `/cowork` move needs no change in this repo.** The nesting happens at the edge, and every internal link on these pages is relative (`href="api.html"`), so they all resolve correctly one path deeper with no content edit and no change to `deploy_docs.yml`. There is no window where the live hostname 404s while files are moved around.

## Held until the route is live

`docs.mindshub.ai/inference` does not resolve until the edge route lands, rehearsed on `docs-next.mindshub.ai` first. Merging before then would ship a banner whose link 404s, which is worse than the dead end it fixes.

**Ready to merge the moment that route is live.** The alternative was to ship now pointing at `github.io` and correct it afterwards; that is a link we would knowingly have to come back to, which is the kind of debt this audit keeps finding.

## Heads up before merge

**Merging this deploys straight to the public `docs.mindshub.ai`.** `.github/workflows/deploy_docs.yml` publishes `docs/` to GitHub Pages on any push to `main` that touches `docs/**`. So this wants a look before merge, not after.

One thing to know if you are reviewing after the cutover: ENG-1744 takes `docs.mindshub.ai` off this repo as a GitHub Pages custom domain, so the site then serves at `mindsdb.github.io/mindshub/` and reaches the public hostname through Cloudflare. The deploy workflow is unchanged either way.

## Type of change

- [x] 📄 Documentation change (content only, no code paths touched)

## Verification

Done locally with headless Chrome over the four files, at 390px (mobile, emulated), 660px and 1280px:

- The banner is above the fold on every page at every width. Its bottom edge sits at 188px at mobile width and 134px at 660px, so no scrolling is needed to see it.
- No horizontal overflow at any width (`scrollWidth == clientWidth` at 390 and 660). The mobile hamburger still behaves as before, and the banner sits outside it so it is visible without opening the menu.
- HTML tag balance checked on all four files: no unclosed or mismatched tags.
- Diff is insertions only apart from the link retarget. Every existing URL still serves what it served before.
- Link targets re-counted after the retarget: 9 references to `docs.mindshub.ai/inference`, 0 remaining to `mindsdb.github.io/mindshub_inference`.

Still owed, and it is why this is not merged yet: the link target returns 200. It cannot until the route exists.

After merge, worth confirming on the live hostname: all four pages still 200 under `/cowork/`, the banner shows, the four legacy root paths 301 into `/cowork/`, and the signpost link resolves.

## Out of scope

Retiring or redirecting the hostname: not happening, `docs.mindshub.ai` keeps Cowork's docs under the same ownership and [ENG-1747](https://linear.app/mindsdb/issue/ENG-1747) is cancelled. Also out of scope: re-sorting the local API reference onto the developer docs, restyling onto the Minds design system, and the stale Mintlify `docs/docs.json` beside these files. The edge route, the Pages custom-domain removal and the legacy-path 301s all belong to ENG-1744.