### PR TITLE
docs: use Inter for docs site headings, drop Josefin Sans (ENG-1800)

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -19,7 +19,7 @@
 <meta name="twitter:description" content="REST API reference for Minds Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Josefin+Sans:wght@300;400;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
 <style>
   :root {
     --bg:        #080d18;
@@ -47,7 +47,7 @@
     --method-put-bg: rgba(167,139,250,0.10);
     --r:    6px; --r-lg: 10px; --r-xl: 16px;
     --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
-    --font-display: 'Josefin Sans', 'Inter', sans-serif;
+    --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
     --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -119,7 +119,7 @@
   .content { min-width: 0; }
   .eyebrow { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
   .eyebrow::before { content: ''; display: block; width: 24px; height: 1px; background: var(--accent); }
-  h1 { font-family: var(--font-display); font-size: clamp(30px, 4vw, 46px); font-weight: 700; letter-spacing: -0.01em; line-height: 1.08; color: var(--ink); margin-bottom: 16px; }
+  h1 { font-family: var(--font-display); font-size: clamp(30px, 4vw, 46px); font-weight: 700; letter-spacing: -0.022em; line-height: 1.08; color: var(--ink); margin-bottom: 16px; }
   .lede { font-size: 16px; line-height: 1.65; color: var(--ink-3); max-width: 60ch; margin-bottom: 52px; }
 
   /* ── Base URL strip ── */

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
 <meta name="twitter:description" content="Documentation for Minds Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Josefin+Sans:wght@300;400;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
 <style>
   :root {
     --bg:        #080d18;
@@ -39,7 +39,7 @@
     --r-lg: 10px;
     --r-xl: 16px;
     --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
-    --font-display: 'Josefin Sans', 'Inter', sans-serif;
+    --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
     --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -149,7 +149,7 @@
     font-family: var(--font-display);
     font-size: clamp(36px, 5vw, 58px);
     font-weight: 700;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.022em;
     line-height: 1.06;
     color: var(--ink);
     margin-bottom: 20px;

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -19,7 +19,7 @@
 <meta name="twitter:description" content="Get started with Minds Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Josefin+Sans:wght@300;400;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
 <style>
   :root {
     --bg:        #080d18;
@@ -40,7 +40,7 @@
     --r-lg: 10px;
     --r-xl: 16px;
     --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
-    --font-display: 'Josefin Sans', 'Inter', sans-serif;
+    --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
     --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -179,7 +179,7 @@
   h1 {
     font-family: var(--font-display);
     font-size: clamp(30px, 4vw, 46px); font-weight: 700;
-    letter-spacing: -0.01em; line-height: 1.08;
+    letter-spacing: -0.022em; line-height: 1.08;
     color: var(--ink); margin-bottom: 16px;
   }
   .lede {

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -19,7 +19,7 @@
 <meta name="twitter:description" content="Explore use cases for Minds Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Josefin+Sans:wght@300;400;700&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
 <style>
   :root {
     --bg:        #080d18;
@@ -42,7 +42,7 @@
     --tint-5: #C4B5FD;
     --r:    6px; --r-lg: 10px; --r-xl: 16px;
     --font-sans:    'Inter', ui-sans-serif, system-ui, sans-serif;
-    --font-display: 'Josefin Sans', 'Inter', sans-serif;
+    --font-display: 'Inter', ui-sans-serif, system-ui, sans-serif;
     --font-mono:    'JetBrains Mono', ui-monospace, monospace;
   }
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -103,7 +103,7 @@
   .hero-wrap { max-width: 1100px; margin: 0 auto; padding: 88px 24px 72px; }
   .eyebrow { font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
   .eyebrow::before { content: ''; display: block; width: 24px; height: 1px; background: var(--accent); }
-  h1 { font-family: var(--font-display); font-size: clamp(32px, 5vw, 54px); font-weight: 700; letter-spacing: -0.01em; line-height: 1.06; color: var(--ink); margin-bottom: 20px; }
+  h1 { font-family: var(--font-display); font-size: clamp(32px, 5vw, 54px); font-weight: 700; letter-spacing: -0.022em; line-height: 1.06; color: var(--ink); margin-bottom: 20px; }
   h1 em { font-style: normal; color: var(--accent); }
   .lede { font-size: 17px; line-height: 1.65; color: var(--ink-3); max-width: 58ch; }
 


### PR DESCRIPTION
Linear: [ENG-1800](https://linear.app/mindsdb/issue/ENG-1800/docs-site-typography-use-inter-for-headings-drop-josefin-sans)

## What

The four pages served at docs.mindshub.ai used Josefin Sans for every heading while their body text was already Inter, so headings and body disagreed and the pages sat off the Minds design system. This points the display face at Inter.

- `--font-display` is now Inter in `docs/index.html`, `docs/setup.html`, `docs/api.html`, `docs/use-cases.html`.
- Josefin Sans is dropped from the Google Fonts request, so each page loads one font file fewer.
- Hero heading tracking tightened from `-0.01em` to `-0.022em`. Inter needs it at 46-58px where Josefin Sans did not.

The monospace face (JetBrains Mono) is unchanged. Colours, layout and spacing are untouched. 12 lines, 3 per page.

## Note on the live site

docs.mindshub.ai publishes from `main`, not `staging`: the live pages match `main` byte for byte, and `docs/setup.html` and `docs/use-cases.html` differ between the two branches. So this lands on the mainline first and reaches the live site at the next release to `main`.

## Test

- No references to Josefin Sans remain under `docs/`.
- Served the four pages locally and confirmed headings render in Inter, body text unchanged.

## Out of scope

Swapping JetBrains Mono for Roboto Mono, the design system's mono face. Bigger visual change, since mono carries the eyebrows, badges, brand mark and code blocks.