### PR TITLE
docs: correct the Cowork product name, and stop serving a June Anton build [ENG-1856]

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -2,21 +2,21 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>API Reference — Minds Cowork Docs</title>
+<title>API Reference — MindsHub Cowork Docs</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="description" content="REST API reference for Minds Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
-<meta name="keywords" content="Minds Cowork API, REST API, AI agent API, conversations API, projects API, artifacts API, schedules API, connectors API" />
+<meta name="description" content="REST API reference for MindsHub Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
+<meta name="keywords" content="MindsHub Cowork API, REST API, AI agent API, conversations API, projects API, artifacts API, schedules API, connectors API" />
 <meta name="robots" content="index, follow" />
-<meta name="author" content="Minds Platform" />
-<meta property="og:title" content="API Reference — Minds Cowork" />
-<meta property="og:description" content="REST API reference for Minds Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
+<meta name="author" content="MindsHub" />
+<meta property="og:title" content="API Reference — MindsHub Cowork" />
+<meta property="og:description" content="REST API reference for MindsHub Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
 <meta property="og:type" content="website" />
-<meta property="og:site_name" content="Minds Cowork" />
+<meta property="og:site_name" content="MindsHub Cowork" />
 <meta property="og:image" content="favicon.png" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@MindsDB" />
-<meta name="twitter:title" content="API Reference — Minds Cowork" />
-<meta name="twitter:description" content="REST API reference for Minds Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
+<meta name="twitter:title" content="API Reference — MindsHub Cowork" />
+<meta name="twitter:description" content="REST API reference for MindsHub Cowork. Endpoints for conversations, projects, artifacts, schedules, files, connectors, memories, skills, and scratchpads." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -275,14 +275,14 @@
          menu, and the only way out of this documentation set should not be
          hidden behind a hamburger. -->
     <a href="/" class="nav-up">&larr; All docs</a>
-    <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
+    <div class="brand"><div class="brand-dot"></div>MindsHub Cowork</div>
     <div class="nav-links">
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html" class="active">API</a>
       <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
-      <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
+      <a href="https://github.com/mindsdb/mindshub">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
       <span></span><span></span><span></span>
@@ -294,7 +294,7 @@
   <div class="api-banner-inner">
     <span class="api-banner-tag">Hosted API</span>
     <span class="api-banner-text">
-      These pages document Minds Cowork, the app and local server you run yourself.
+      These pages document MindsHub Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
       <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
@@ -1540,7 +1540,7 @@
 </div>
 
 <footer>
-  Minds Platform · Open Source · <a href="https://github.com/mindsdb/minds-platform">github.com/mindsdb/minds-platform</a>
+  MindsHub · Open Source · <a href="https://github.com/mindsdb/mindshub">github.com/mindsdb/mindshub</a>
 </footer>
 
 <script>
@@ -1576,4 +1576,5 @@
 </script>
 </body>
 </html>
+
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,21 +2,21 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Minds Cowork — Docs</title>
+<title>MindsHub Cowork — Docs</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="description" content="Documentation for Minds Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
-<meta name="keywords" content="Minds Cowork, AI platform, AI automation, knowledge workers, open source AI, workflow automation, documentation" />
+<meta name="description" content="Documentation for MindsHub Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
+<meta name="keywords" content="MindsHub Cowork, AI platform, AI automation, knowledge workers, open source AI, workflow automation, documentation" />
 <meta name="robots" content="index, follow" />
-<meta name="author" content="Minds Platform" />
-<meta property="og:title" content="Minds Cowork — Docs" />
-<meta property="og:description" content="Documentation for Minds Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
+<meta name="author" content="MindsHub" />
+<meta property="og:title" content="MindsHub Cowork — Docs" />
+<meta property="og:description" content="Documentation for MindsHub Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
 <meta property="og:type" content="website" />
-<meta property="og:site_name" content="Minds Cowork" />
+<meta property="og:site_name" content="MindsHub Cowork" />
 <meta property="og:image" content="favicon.png" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@MindsDB" />
-<meta name="twitter:title" content="Minds Cowork — Docs" />
-<meta name="twitter:description" content="Documentation for Minds Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
+<meta name="twitter:title" content="MindsHub Cowork — Docs" />
+<meta name="twitter:description" content="Documentation for MindsHub Cowork — an open-source AI platform for knowledge workers. Automate recurring tasks, create apps and artifacts, and deploy anywhere." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -342,7 +342,7 @@
     <a href="/" class="nav-up">&larr; All docs</a>
     <div class="brand">
       <div class="brand-dot"></div>
-      Minds Cowork
+      MindsHub Cowork
     </div>
     <div class="nav-links">
       <a href="index.html" class="active">Docs</a>
@@ -350,7 +350,7 @@
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
       <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
-      <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
+      <a href="https://github.com/mindsdb/mindshub">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
       <span></span><span></span><span></span>
@@ -362,7 +362,7 @@
   <div class="api-banner-inner">
     <span class="api-banner-tag">Hosted API</span>
     <span class="api-banner-text">
-      These pages document Minds Cowork, the app and local server you run yourself.
+      These pages document MindsHub Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
       <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
@@ -371,7 +371,7 @@
 
 <div class="hero-wrap">
   <div class="eyebrow">Documentation</div>
-  <h1>Build and automate<br>with <span>Minds Cowork</span></h1>
+  <h1>Build and automate<br>with <span>MindsHub Cowork</span></h1>
   <p class="lede">
     A general-purpose AI platform for knowledge workers. Automate recurring tasks,
     create artifacts, and deploy anywhere — on your terms.
@@ -436,7 +436,7 @@
 </div>
 
 <footer>
-  Minds Platform · Open Source · <a href="https://github.com/mindsdb/minds-platform">github.com/mindsdb/minds-platform</a>
+  MindsHub · Open Source · <a href="https://github.com/mindsdb/mindshub">github.com/mindsdb/mindshub</a>
 </footer>
 
 <script>
@@ -452,4 +452,5 @@
 </script>
 </body>
 </html>
+
 

--- a/docs/setup.html
+++ b/docs/setup.html
@@ -2,21 +2,21 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Setup — Minds Cowork Docs</title>
+<title>Setup — MindsHub Cowork Docs</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="description" content="Get started with Minds Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
-<meta name="keywords" content="Minds Cowork setup, install, get started, download, Electron app, Docker, build from source, Node.js, Python" />
+<meta name="description" content="Get started with MindsHub Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
+<meta name="keywords" content="MindsHub Cowork setup, install, get started, download, Electron app, Docker, build from source, Node.js, Python" />
 <meta name="robots" content="index, follow" />
-<meta name="author" content="Minds Platform" />
-<meta property="og:title" content="Setup — Minds Cowork" />
-<meta property="og:description" content="Get started with Minds Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
+<meta name="author" content="MindsHub" />
+<meta property="og:title" content="Setup — MindsHub Cowork" />
+<meta property="og:description" content="Get started with MindsHub Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
 <meta property="og:type" content="website" />
-<meta property="og:site_name" content="Minds Cowork" />
+<meta property="og:site_name" content="MindsHub Cowork" />
 <meta property="og:image" content="favicon.png" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@MindsDB" />
-<meta name="twitter:title" content="Setup — Minds Cowork" />
-<meta name="twitter:description" content="Get started with Minds Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
+<meta name="twitter:title" content="Setup — MindsHub Cowork" />
+<meta name="twitter:description" content="Get started with MindsHub Cowork. Download the pre-built desktop or web app, or build from source with Node.js, Python, and Docker." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -385,14 +385,14 @@
          menu, and the only way out of this documentation set should not be
          hidden behind a hamburger. -->
     <a href="/" class="nav-up">&larr; All docs</a>
-    <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
+    <div class="brand"><div class="brand-dot"></div>MindsHub Cowork</div>
     <div class="nav-links">
       <a href="index.html">Docs</a>
       <a href="setup.html" class="active">Setup</a>
       <a href="use-cases.html">Use Cases</a>
       <a href="api.html">API</a>
       <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
-      <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
+      <a href="https://github.com/mindsdb/mindshub">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
       <span></span><span></span><span></span>
@@ -404,7 +404,7 @@
   <div class="api-banner-inner">
     <span class="api-banner-tag">Hosted API</span>
     <span class="api-banner-text">
-      These pages document Minds Cowork, the app and local server you run yourself.
+      These pages document MindsHub Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
       <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
@@ -434,7 +434,7 @@
     <div class="eyebrow">Setup</div>
     <h1>Get Started</h1>
     <p class="lede">
-      The simplest way to use Minds Cowork is the pre-built app — available on web and desktop.
+      The simplest way to use MindsHub Cowork is the pre-built app — available on web and desktop.
     </p>
 
     <!-- Desktop App download -->
@@ -455,7 +455,7 @@
           </div>
           <div class="dl-arrow">↗</div>
         </a>
-        <a class="download-card" href="https://downloads.mindsdb.com/anton/mac/anton-latest.pkg" target="_blank">
+        <a class="download-card" href="https://downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg" target="_blank">
           <div class="dl-icon">
             <svg width="22" height="22" viewBox="0 0 814 1000" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="color:var(--ink-2)">
               <path d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76 0-103.7 40.8-165.9 40.8s-105-43.4-150.3-116.6c-52.1-83.6-94.1-208.7-94.1-328.2 0-191.3 124.1-292.5 246.9-292.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/>
@@ -471,7 +471,7 @@
             </svg>
           </div>
         </a>
-        <a class="download-card" href="https://downloads.mindsdb.com/anton/windows/anton-latest.exe" target="_blank">
+        <a class="download-card" href="https://downloads.mindshub.ai/mindshub-cowork/windows/mindshub-cowork-latest.exe" target="_blank">
           <div class="dl-icon">
             <svg width="22" height="22" viewBox="0 0 88 88" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="color:var(--ink-2)">
               <path d="M0 12.402l35.687-4.86.016 34.423-35.67.203zm35.67 33.529l.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349l-.015 41.344-47.318-6.63-.066-34.893z"/>
@@ -532,8 +532,8 @@
       <p>Clone with <code>--recurse-submodules</code> to pull <code>frontend</code>, <code>backend/core_api</code>, and <code>backend/core_agent</code> in one shot.</p>
       <div class="code-block">
         <div class="code-header"><span class="code-lang">bash</span></div>
-        <pre><span class="hl">git</span> clone --recurse-submodules https://github.com/mindsdb/minds-platform.git
-<span class="hl">cd</span> minds-platform
+        <pre><span class="hl">git</span> clone --recurse-submodules https://github.com/mindsdb/mindshub.git
+<span class="hl">cd</span> mindshub
 <span class="hl">make</span> setup</pre>
       </div>
       <p><code>make setup</code> runs <code>npm ci</code> for the frontend and <code>uv sync</code> for both Python backends. It is automatically skipped on subsequent runs if nothing changed in the lock files.</p>
@@ -638,7 +638,7 @@ make flush FORCE=1  # no prompt (CI / scripts)</code></pre>
 </div>
 
 <footer>
-  Minds Platform · Open Source · <a href="https://github.com/mindsdb/minds-platform">github.com/mindsdb/minds-platform</a>
+  MindsHub · Open Source · <a href="https://github.com/mindsdb/mindshub">github.com/mindsdb/mindshub</a>
 </footer>
 
 <script>
@@ -674,4 +674,5 @@ make flush FORCE=1  # no prompt (CI / scripts)</code></pre>
 </script>
 </body>
 </html>
+
 

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -2,21 +2,21 @@
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<title>Use Cases — Minds Cowork Docs</title>
+<title>Use Cases — MindsHub Cowork Docs</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta name="description" content="Explore use cases for Minds Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
-<meta name="keywords" content="AI use cases, AI automation, workflow automation, AI for teams, content automation, data reports, knowledge workers, Minds Cowork" />
+<meta name="description" content="Explore use cases for MindsHub Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
+<meta name="keywords" content="AI use cases, AI automation, workflow automation, AI for teams, content automation, data reports, knowledge workers, MindsHub Cowork" />
 <meta name="robots" content="index, follow" />
-<meta name="author" content="Minds Platform" />
-<meta property="og:title" content="Use Cases — Minds Cowork" />
-<meta property="og:description" content="Explore use cases for Minds Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
+<meta name="author" content="MindsHub" />
+<meta property="og:title" content="Use Cases — MindsHub Cowork" />
+<meta property="og:description" content="Explore use cases for MindsHub Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
 <meta property="og:type" content="website" />
-<meta property="og:site_name" content="Minds Cowork" />
+<meta property="og:site_name" content="MindsHub Cowork" />
 <meta property="og:image" content="favicon.png" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@MindsDB" />
-<meta name="twitter:title" content="Use Cases — Minds Cowork" />
-<meta name="twitter:description" content="Explore use cases for Minds Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
+<meta name="twitter:title" content="Use Cases — MindsHub Cowork" />
+<meta name="twitter:description" content="Explore use cases for MindsHub Cowork. See how creators, operators, strategists, and teams automate workflows and build AI-powered apps, reports, and dashboards." />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -270,14 +270,14 @@
          menu, and the only way out of this documentation set should not be
          hidden behind a hamburger. -->
     <a href="/" class="nav-up">&larr; All docs</a>
-    <div class="brand"><div class="brand-dot"></div>Minds Cowork</div>
+    <div class="brand"><div class="brand-dot"></div>MindsHub Cowork</div>
     <div class="nav-links">
       <a href="index.html">Docs</a>
       <a href="setup.html">Setup</a>
       <a href="use-cases.html" class="active">Use Cases</a>
       <a href="api.html">API</a>
       <a href="https://docs.mindshub.ai/inference/">Hosted API</a>
-      <a href="https://github.com/mindsdb/minds-platform">GitHub ↗</a>
+      <a href="https://github.com/mindsdb/mindshub">GitHub ↗</a>
     </div>
     <button class="hamburger" aria-label="Toggle menu">
       <span></span><span></span><span></span>
@@ -289,7 +289,7 @@
   <div class="api-banner-inner">
     <span class="api-banner-tag">Hosted API</span>
     <span class="api-banner-text">
-      These pages document Minds Cowork, the app and local server you run yourself.
+      These pages document MindsHub Cowork, the app and local server you run yourself.
       For the hosted MindsHub API at api.mindshub.ai, with API keys, see the
       <a href="https://docs.mindshub.ai/inference/" target="_blank" rel="noopener">hosted MindsHub API docs ↗</a>.
     </span>
@@ -300,7 +300,7 @@
   <div class="eyebrow">Use Cases</div>
   <h1>Two things.<br><em>Automate</em> and <em>Create.</em></h1>
   <p class="lede">
-    Minds Cowork is built around two core primitives. Everything below is an expression of one or both.
+    MindsHub Cowork is built around two core primitives. Everything below is an expression of one or both.
   </p>
   <div class="primitives">
     <div class="primitive">
@@ -442,7 +442,7 @@
 </div>
 
 <footer>
-  Minds Platform · Open Source · <a href="https://github.com/mindsdb/minds-platform">github.com/mindsdb/minds-platform</a>
+  MindsHub · Open Source · <a href="https://github.com/mindsdb/mindshub">github.com/mindsdb/mindshub</a>
 </footer>
 
 <script>
@@ -458,4 +458,5 @@
 </script>
 </body>
 </html>
+
 


### PR DESCRIPTION
Linear: [ENG-1856](https://linear.app/mindsdb/issue/ENG-1856). **Hotfix to `main`** — the Cowork docs publish from there, and all of this is live right now.

## The actual defect: the download buttons

`docs/setup.html` was handing out this:

| | Was | Now |
|---|---|---|
| macOS | `downloads.mindsdb.com/anton/mac/anton-latest.pkg` — 218 MB, **20 Jun 2026** | `downloads.mindshub.ai/mindshub-cowork/mac/mindshub-cowork-latest.pkg` — 222 MB, 20 Aug 2026 |
| Windows | `downloads.mindsdb.com/anton/windows/anton-latest.exe` | `downloads.mindshub.ai/mindshub-cowork/windows/mindshub-cowork-latest.exe` — 110 MB, 20 Aug 2026 |

Old domain, old product name, **two months stale**. Anyone coming to these docs for MindsHub Cowork got a June Anton build. Both replacements verified 200.

The naming below is what led me here; this is the part that was hurting users.

## Naming

| Wrong | Count | Now |
|---|---|---|
| `Minds Cowork` | **43** — titles, meta descriptions, keywords, `og:*`, `twitter:*`, `og:site_name`, nav, `h1`, body | `MindsHub Cowork` |
| `Minds Platform` | **8** — `author` meta tags and footers | `MindsHub` |
| `github.com/mindsdb/minds-platform` | **10** | `github.com/mindsdb/mindshub` |

**Not a preference.** The marketing site uses "MindsHub Cowork" 41 times, the `cowork` app repo in 39 files, the console frontend in 5 — and none of them contains "Minds Cowork" at all. These four pages were the only outlier, which is why the chooser page at `docs.mindshub.ai/` inherited it.

## Two things that needed care rather than a global replace

**The clone instruction is two lines that have to agree.** `setup.html` had:

```
git clone --recurse-submodules https://github.com/mindsdb/minds-platform.git
cd minds-platform
```

The `cd` is a bare directory name, so a URL substitution cannot reach it. Changing only the URL leaves an instruction that fails on its second line — worse than changing neither. Both moved together.

**26 other `mindsdb` strings are deliberately untouched.** `mindsdb.github.io/anton` and `mindsdb.github.io/engine` are live, separate products, and where they should point is a content decision rather than a rename. **Asserted per file that the `mindsdb.github.io` count is unchanged**, so a blanket `mindsdb` → `mindshub` cannot have crept in.

## A guard worth mentioning

Every file was asserted over 5 KB before editing. My first attempt read the four files from `hotfix/eng-1800-docs-inter-typography` — which had merged and been deleted an hour earlier — got four empty strings, and every "the bad string is gone" assertion passed **vacuously**. The size guard exists so that cannot pass silently again.

## Companion change

The chooser page has the same two occurrences, fixed on <pull-request href="https://github.com/mindsdb/mindshub_inference/pull/442">mindsdb/mindshub_inference#442</pull-request>. That one does **not** ship by merging — `root-page.js` is bundled into the Cloudflare Worker, so it needs a `wrangler deploy`.

## Verify after deploy

```sh
curl -sS https://docs.mindshub.ai/cowork/ | grep -c 'Minds Cowork'     # 0
curl -sS https://docs.mindshub.ai/cowork/setup.html | grep -o 'downloads[^"]*'
```